### PR TITLE
fix(iothub-manager): Fixing cache exception when calculating TTL for non-existent cache

### DIFF
--- a/src/services/iothub-manager/Services/DeviceQueryCache.cs
+++ b/src/services/iothub-manager/Services/DeviceQueryCache.cs
@@ -52,15 +52,14 @@ namespace Mmm.Iot.IoTHubManager.Services
                     queryString,
                     out cachedResult);
 
-                if (cachedResult.ResultTimestamp.AddMinutes(1) < DateTimeOffset.Now)
+                if (!cacheHasQuery)
+                {
+                    return null;
+                }
+                else if (cachedResult.ResultTimestamp.AddMinutes(1) < DateTimeOffset.Now)
                 {
                     // remove the cached result if it is older than a single minute - this is our TTL
                     cachedTenantValue.QueryStringCache.Remove(queryString);
-                    return null;
-                }
-
-                if (!cacheHasQuery)
-                {
                     return null;
                 }
             }


### PR DESCRIPTION
This fixes an error where the TTL is being calculated for a cache entry that does not exist, and thus throws a `NullReferenceException`. You can view this bug on display in our dev instance.

[dev space](http://cache-fix.s.default.reverse-proxy.7b47mhqr49.cus.azds.io/dashboard)