### PR TITLE
chore(release-pipeline): replace '+' character with '_' character in …

### DIFF
--- a/pipelines/cd/release.yaml
+++ b/pipelines/cd/release.yaml
@@ -153,12 +153,17 @@ stages:
               command: tag
               arguments: $(dockerHubRepositoryName)/$(serviceName):$(semVerMetaBuild) $(dockerHubRepositoryName)/$(serviceName):$(semVer)
 
+          - bash: |-
+              semVerMetaDocker = $(echo '$(semVerMeta)' | sed 's/\+/_/g')
+              echo "##vso[task.setvariable variable=semVerMetaDocker]$semVerMetaDocker"
+            displayName: Adapt SemVer for use as Docker tag
+
           - task: Docker@2
             displayName: Apply version tag with metadata
             inputs:
               containerRegistry: $(dockerHubServiceConnectionName)
               command: tag
-              arguments: $(dockerHubRepositoryName)/$(serviceName):$(semVerMetaBuild) $(dockerHubRepositoryName)/$(serviceName):$(semVerMeta)
+              arguments: $(dockerHubRepositoryName)/$(serviceName):$(semVerMetaBuild) $(dockerHubRepositoryName)/$(serviceName):$(semVerMetaDocker)
 
           - task: Docker@2
             displayName: Push image


### PR DESCRIPTION
…SemVer with metadata string to make usable as Docker tag

Docker tags do not allow plus characters: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
In addition, because Kubernetes labels also disallow the plus character, Helm has adopted the convention of replacing the plus with an underscore: https://helm.sh/docs/chart_best_practices/conventions/#version-numbers
So, we use that approach here too