### PR TITLE
chore(repo): Add issues integration with Azure Boards

### DIFF
--- a/.github/workflows/issues-integration.yml
+++ b/.github/workflows/issues-integration.yml
@@ -1,0 +1,22 @@
+name: Sync issue to Azure DevOps work item
+
+on:
+  issues:
+    types:
+      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: danhellem/github-actions-issue-to-work-item@master
+        env:
+          ado_token: "${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}"
+          github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
+          ado_organization: "3M-Bluebird"
+          ado_project: "AzurePlatform"
+          ado_area_path: "\\AzurePlatform\\Platform 5.x"
+          ado_wit: "User Story"
+          ado_new_state: "New"
+          ado_close_state: "Closed"
+          ado_bypassrules: true


### PR DESCRIPTION
Adding a github action for [issues integration with azure devops](https://github.com/marketplace/actions/github-issues-to-azure-devops) that will create an Azure Boards work item when an issue is created.