### PR TITLE
14465 no tenant logo fix

### DIFF
--- a/src/webui/src/components/shell/shell.scss
+++ b/src/webui/src/components/shell/shell.scss
@@ -23,7 +23,7 @@ $companySvgSize: 23px;
 
   .nav-item-icon {
     img {
-      max-height: 24px;
+      max-height: 23px;
       vertical-align: middle;
       @include rem-fallback(margin, 10px);
     }
@@ -33,6 +33,20 @@ $companySvgSize: 23px;
 
   @include themify($themes) {
     .nav-item-icon svg { fill: themed('colorNavText'); }
+  }
+}
+
+span[class*='Masthead_masthead-branding']{
+
+  .nav-item-icon {
+    margin-Bottom: 3px;
+  }
+
+  .nav-item-icon svg {
+    height: 23px;
+    width: auto;
+    @include rem-fallback(margin, 10px);
+    margin-Bottom:6px;
   }
 }
 


### PR DESCRIPTION
Simple update to the shell.css to improve formatting on a tenant that uses the default svg logo.  Also fixed a readme link.

[AB#14465](https://dev.azure.com/3M-Bluebird/150135ff-890c-41c0-8f52-1cfcd5f891df/_workitems/edit/14465)