### PR TITLE
feat(webui): Time interval dropdown in device-details flyout

### DIFF
--- a/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.container.js
+++ b/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.container.js
@@ -4,9 +4,11 @@ import { connect } from "react-redux";
 import { withNamespaces } from "react-i18next";
 import { DeviceDetails } from "./deviceDetails";
 import {
+    redux as appRedux,
     getTheme,
     getDeviceGroups,
     getTimeSeriesExplorerUrl,
+    getTimeInterval,
 } from "store/reducers/appReducer";
 import {
     epics as ruleEpics,
@@ -35,6 +37,7 @@ const mapStateToProps = (state, props) => ({
         deviceModuleStatus: getDeviceModuleStatus(state),
         isDeviceModuleStatusPending: getDeviceModuleStatusPendingStatus(state),
         deviceModuleStatusError: getDeviceModuleStatusError(state),
+        timeInterval: getTimeInterval(state),
     }),
     // Wrap the dispatch method
     mapDispatchToProps = (dispatch) => ({
@@ -47,6 +50,8 @@ const mapStateToProps = (state, props) => ({
                     devicesEpics.actions.fetchEdgeAgent
                 )
             ),
+        updateTimeInterval: (timeInterval) =>
+            dispatch(appRedux.actions.updateTimeInterval(timeInterval)),
     });
 
 export const DeviceDetailsContainer = withNamespaces()(

--- a/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.js
+++ b/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.js
@@ -33,6 +33,7 @@ import {
     SectionDesc,
     TimeSeriesInsightsLinkContainer,
 } from "components/shared";
+import { TimeIntervalDropdownContainer as TimeIntervalDropdown } from "components/shell/timeIntervalDropdown";
 import Flyout from "components/shared/flyout";
 import {
     TelemetryChartContainer as TelemetryChart,
@@ -125,7 +126,10 @@ export class DeviceDetails extends Component {
                 .do((_) => this.setState({ telemetry: {} }))
                 .switchMap(
                     (deviceId) =>
-                        TelemetryService.getTelemetryByDeviceIdP15M([deviceId])
+                        TelemetryService.getTelemetryByDeviceId(
+                            [deviceId],
+                            TimeIntervalDropdown.getTimeIntervalDropdownValue()
+                        )
                             .merge(
                                 this.telemetryRefresh$ // Previous request complete
                                     .delay(
@@ -258,6 +262,11 @@ export class DeviceDetails extends Component {
         );
     };
 
+    updateTimeInterval = (timeInterval) => {
+        this.props.updateTimeInterval(timeInterval);
+        this.resetTelemetry$.next(this.props.device.id);
+    };
+
     render() {
         const {
                 t,
@@ -362,6 +371,12 @@ export class DeviceDetails extends Component {
                                     )}
                                 </Section.Header>
                                 <Section.Content>
+                                    <TimeIntervalDropdown
+                                        onChange={this.updateTimeInterval}
+                                        value={this.props.timeInterval}
+                                        t={t}
+                                        className="device-details-time-interval-dropdown"
+                                    />
                                     {timeSeriesExplorerUrl && (
                                         <TimeSeriesInsightsLinkContainer
                                             href={timeSeriesParamUrl}

--- a/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.scss
+++ b/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.scss
@@ -60,5 +60,10 @@
     .device-properties-actions .row { color: themed('colorContentTextDim'); }
 
     .device-details-deployment-contentbox { border-color: themed('colorHeaderBorderColor'); }
+
+    .device-details-time-interval-dropdown {
+      border-top-color: 1px solid themed('color-border-rest');
+      border-bottom-color: 1px solid themed('color-border-rest');
+    }
   }
 }

--- a/src/webui/src/components/shell/timeIntervalDropdown/timeIntervalDropdown.js
+++ b/src/webui/src/components/shell/timeIntervalDropdown/timeIntervalDropdown.js
@@ -33,13 +33,15 @@ export class TimeIntervalDropdown extends Component {
 
     render() {
         const options = optionValues.map(({ value }) => ({
-            label: this.props.t(`timeInterval.${value}`),
-            value,
-        }));
+                label: this.props.t(`timeInterval.${value}`),
+                value,
+            })),
+            className = this.props.className || "time-interval-dropdown";
+
         return (
             <SelectInput
                 name="time-interval-dropdown"
-                className="time-interval-dropdown"
+                className={className}
                 attr={{
                     select: {
                         className: "time-interval-dropdown-select",


### PR DESCRIPTION
Adding an instance of the `TimeIntervalDropdown` component, that we see on the dashboard and maintenance pages, to the device-details flyout for a single device. This dropdown can then be used to show different time frames for the small telemetry chart that appears on the device details flyout. Changing the value of this dropdown has a global affect on the other instances of the component. For instance, from the device details flyout, if I set the value of the `TimeIntervalDropdown` to "last month", I will see the last months worth of data for my single device, if I then close the flyout, and switch pages to the dashboard, the value of the `TimeIntervalDropdown` component on the dashboard remains set to "last month" - essentially, the value of this dropdown is shared amongst all instances of this component.

As part of a series of fixes for #20 
[AB#14957](https://dev.azure.com/3M-Bluebird/150135ff-890c-41c0-8f52-1cfcd5f891df/_workitems/edit/14957)

[Dev Space](http://joe-device-details-time.s.default.reverse-proxy.cwnxvsfdmm.cus.azds.io/)