### PR TITLE
feat(webui): Added default firmware templating through UI/Config solution settings

### DIFF
--- a/src/services/config/Services/IStorage.cs
+++ b/src/services/config/Services/IStorage.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Mmm.Iot.Common.Services.External.StorageAdapter;
 using Mmm.Iot.Config.Services.External;
 using Mmm.Iot.Config.Services.Models;
 using Mmm.Platform.IoT.Common.Services.Models;
@@ -24,6 +25,10 @@ namespace Mmm.Iot.Config.Services
         Task<Logo> GetLogoAsync();
 
         Task<Logo> SetLogoAsync(Logo model);
+
+        Task<ValueApiModel> SetSolutionSettingAsync(string id, object setting);
+
+        Task<T> GetSolutionSettingAsync<T>(string id);
 
         Task<IEnumerable<DeviceGroup>> GetAllDeviceGroupsAsync();
 

--- a/src/services/config/Services/IStorage.cs
+++ b/src/services/config/Services/IStorage.cs
@@ -14,9 +14,9 @@ namespace Mmm.Iot.Config.Services
 {
     public interface IStorage
     {
-        Task<object> GetThemeAsync();
+        Task<Theme> GetThemeAsync();
 
-        Task<object> SetThemeAsync(object theme);
+        Task<Theme> SetThemeAsync(object theme);
 
         Task<object> GetUserSetting(string id);
 

--- a/src/services/config/Services/Models/Theme.cs
+++ b/src/services/config/Services/Models/Theme.cs
@@ -12,8 +12,10 @@ namespace Mmm.Iot.Config.Services.Models
             Description = "My Solution Description",
         };
 
-        public string Name { get; private set; }
+        public string Name { get; set; }
 
-        public string Description { get; private set; }
+        public string Description { get; set; }
+
+        public string AzureMapsKey { get; set; }
     }
 }

--- a/src/services/config/Services/Storage.cs
+++ b/src/services/config/Services/Storage.cs
@@ -62,30 +62,40 @@ namespace Mmm.Iot.Config.Services
 
         public async Task<object> GetThemeAsync()
         {
-            string data;
+            object data;
 
             try
             {
-                var response = await this.client.GetAsync(SolutionCollectionId, ThemeKey);
-                data = response.Data;
+                data = await this.GetSolutionSettingAsync<object>(ThemeKey);
             }
             catch (ResourceNotFoundException)
             {
-                data = JsonConvert.SerializeObject(Theme.Default);
+                data = Theme.Default;
             }
 
-            var themeOut = JsonConvert.DeserializeObject(data) as JToken ?? new JObject();
+            var themeOut = data as JToken ?? new JObject();
             this.AppendAzureMapsKey(themeOut);
             return themeOut;
         }
 
         public async Task<object> SetThemeAsync(object themeIn)
         {
-            var value = JsonConvert.SerializeObject(themeIn);
-            var response = await this.client.UpdateAsync(SolutionCollectionId, ThemeKey, value, "*");
+            var response = await this.SetSolutionSettingAsync(ThemeKey, themeIn);
             var themeOut = JsonConvert.DeserializeObject(response.Data) as JToken ?? new JObject();
             this.AppendAzureMapsKey(themeOut);
             return themeOut;
+        }
+
+        public async Task<ValueApiModel> SetSolutionSettingAsync(string id, object setting)
+        {
+            var value = JsonConvert.SerializeObject(setting);
+            return await this.client.UpdateAsync(SolutionCollectionId, id, value, "*");
+        }
+
+        public async Task<T> GetSolutionSettingAsync<T>(string id)
+        {
+            var response = await this.client.GetAsync(SolutionCollectionId, id);
+            return JsonConvert.DeserializeObject<T>(response.Data);
         }
 
         public async Task<object> GetUserSetting(string id)
@@ -112,8 +122,7 @@ namespace Mmm.Iot.Config.Services
         {
             try
             {
-                var response = await this.client.GetAsync(SolutionCollectionId, LogoKey);
-                return JsonConvert.DeserializeObject<Logo>(response.Data);
+                return await this.GetSolutionSettingAsync<Logo>(LogoKey);
             }
             catch (ResourceNotFoundException)
             {
@@ -138,8 +147,7 @@ namespace Mmm.Iot.Config.Services
                 }
             }
 
-            var value = JsonConvert.SerializeObject(model);
-            var response = await this.client.UpdateAsync(SolutionCollectionId, LogoKey, value, "*");
+            var response = await this.SetSolutionSettingAsync(LogoKey, model);
             return JsonConvert.DeserializeObject<Logo>(response.Data);
         }
 

--- a/src/services/config/Services/Storage.cs
+++ b/src/services/config/Services/Storage.cs
@@ -60,29 +60,28 @@ namespace Mmm.Iot.Config.Services
             this.logger = logger;
         }
 
-        public async Task<object> GetThemeAsync()
+        public async Task<Theme> GetThemeAsync()
         {
-            object data;
+            Theme theme;
 
             try
             {
-                data = await this.GetSolutionSettingAsync<object>(ThemeKey);
+                theme = await this.GetSolutionSettingAsync<Theme>(ThemeKey);
             }
             catch (ResourceNotFoundException)
             {
-                data = Theme.Default;
+                theme = Theme.Default;
             }
 
-            var themeOut = data as JToken ?? new JObject();
-            this.AppendAzureMapsKey(themeOut);
-            return themeOut;
+            theme.AzureMapsKey ??= this.config.ConfigService.AzureMapsKey;
+            return theme;
         }
 
-        public async Task<object> SetThemeAsync(object themeIn)
+        public async Task<Theme> SetThemeAsync(object themeIn)
         {
             var response = await this.SetSolutionSettingAsync(ThemeKey, themeIn);
-            var themeOut = JsonConvert.DeserializeObject(response.Data) as JToken ?? new JObject();
-            this.AppendAzureMapsKey(themeOut);
+            Theme themeOut = JsonConvert.DeserializeObject<Theme>(response.Data);
+            themeOut.AzureMapsKey ??= this.config.ConfigService.AzureMapsKey;
             return themeOut;
         }
 
@@ -535,14 +534,6 @@ namespace Mmm.Iot.Config.Services
             {
                 this.logger.LogError("Attempted to find a device group name for a tenant with no storage adapter collection. Returning false.", e);
                 return false;
-            }
-        }
-
-        private void AppendAzureMapsKey(JToken theme)
-        {
-            if (theme[AzureMapsKey] == null)
-            {
-                theme[AzureMapsKey] = this.config.ConfigService.AzureMapsKey;
             }
         }
 

--- a/src/services/config/WebService/Controllers/SolutionSettingsController.cs
+++ b/src/services/config/WebService/Controllers/SolutionSettingsController.cs
@@ -34,14 +34,14 @@ namespace Mmm.Iot.Config.WebService.Controllers
 
         [HttpGet("solution-settings/theme")]
         [Authorize("ReadAll")]
-        public async Task<object> GetThemeAsync()
+        public async Task<Theme> GetThemeAsync()
         {
             return await this.storage.GetThemeAsync();
         }
 
         [HttpPut("solution-settings/theme")]
         [Authorize("ReadAll")]
-        public async Task<object> SetThemeAsync([FromBody] object theme)
+        public async Task<Theme> SetThemeAsync([FromBody] Theme theme)
         {
             return await this.storage.SetThemeAsync(theme);
         }

--- a/src/services/config/WebService/Models/DefaultFirmwareSettingApiModel.cs
+++ b/src/services/config/WebService/Models/DefaultFirmwareSettingApiModel.cs
@@ -1,0 +1,13 @@
+// <copyright file="DefaultFirmwareSettingApiModel.cs" company="3M">
+// Copyright (c) 3M. All rights reserved.
+// </copyright>
+
+namespace Mmm.Iot.Config.WebService.Models
+{
+    public class DefaultFirmwareSettingApiModel
+    {
+        public object JsObject { get; set; }
+
+        public DefaultFirmwareSettingMetadataModel Metadata { get; set; }
+    }
+}

--- a/src/services/config/WebService/Models/DefaultFirmwareSettingMetadataModel.cs
+++ b/src/services/config/WebService/Models/DefaultFirmwareSettingMetadataModel.cs
@@ -1,0 +1,11 @@
+// <copyright file="DefaultFirmwareSettingMetadataModel.cs" company="3M">
+// Copyright (c) 3M. All rights reserved.
+// </copyright>
+
+namespace Mmm.Iot.Config.WebService.Models
+{
+    public class DefaultFirmwareSettingMetadataModel
+    {
+        public string Version { get; set; }
+    }
+}

--- a/src/webui/public/locales/en/translations.json
+++ b/src/webui/public/locales/en/translations.json
@@ -120,7 +120,50 @@
         "sendDiagnosticsCheckbox": "Yes, share information with Microsoft",
         "dontSendDiagnosticsCheckbox": "No, don't share information with Microsoft",
         "sendDiagnosticsMicrosoftPrivacyUrl": "Privacy Statement",
-        "diagnosticsLoadError": "Error updating diagnostics preference"
+        "diagnosticsLoadError": "Error updating diagnostics preference",
+        "firmware": {
+            "error": {
+                "noVersion": "The value ${version} must be defined in your firmware JSON template.",
+                "uploadError": "An error occurred while uploading your firmware JSON template",
+                "invalid": "Invalid firmware JSON template entry",
+                "unknown": "An unknown error occurred.",
+                "retrievalError": "An error occurred while retrieving the current firmware JSON template",
+                "doubleSlash": "Firmware JSON template keys may not contain '//'",
+                "reserved": {
+                    "id": "The key 'id' is reserved and cannot be used in the firmware JSON template"
+                }
+            },
+            "name": "Firmware JSON Template",
+            "description": "Upload a firmware JSON template for use with firmware package upload on the packages page.",
+            "edit": "Edit",
+            "save": "Save",
+            "cancel": "Cancel",
+            "variables": {
+                "name": "Template Variables",
+                "summary": "The following template variables may be used in your firmware JSON template. Usage: ${parent.child}, e.g ${blobData.FileUri}",
+                "grid": {
+                    "parent": "Parent",
+                    "child": "Child",
+                    "description": "Description"
+                },
+                "descriptions": {
+                    "version": "Parent only. This variable is required in your template and is overwritten with your firmware package's version value. Usage: ${version}",
+                    "blobData": {
+                        "FileUri": "The Blob Storage URI for your uploaded firmware file",
+                        "CheckSum": "The CheckSum value for your blob storage uploaded file"
+                    },
+                    "packageFile": {
+                        "name": "The name of your uploaded firmware file",
+                        "lastModified": "MS from epoch timestamp",
+                        "lastModifiedDate": "Human readable date timestamp",
+                        "size": "File size in bytes",
+                        "type": "Uploaded file type"
+                    }
+                }
+            }
+            
+
+        }
     },
     "helpFlyout": {
         "title": "Documentation"

--- a/src/webui/public/locales/en/translations.json
+++ b/src/webui/public/locales/en/translations.json
@@ -124,10 +124,10 @@
         "firmware": {
             "error": {
                 "noVersion": "The value ${version} must be defined in your firmware JSON template.",
-                "uploadError": "An error occurred while uploading your firmware JSON template",
+                "upload": "An error occurred while uploading your firmware JSON template",
                 "invalid": "Invalid firmware JSON template entry",
                 "unknown": "An unknown error occurred.",
-                "retrievalError": "An error occurred while retrieving the current firmware JSON template",
+                "retrieval": "An error occurred while retrieving the current firmware JSON template",
                 "doubleSlash": "Firmware JSON template keys may not contain '//'",
                 "reserved": {
                     "id": "The key 'id' is reserved and cannot be used in the firmware JSON template"

--- a/src/webui/public/locales/en/translations.json
+++ b/src/webui/public/locales/en/translations.json
@@ -958,6 +958,8 @@
                 "browse": "Browse",
                 "browseFirmwareText": "for a firmware file",
                 "browseText": "for a package file",
+                "firmwareTemplateTip": "Initial JSON data is derived from your template. You can view and edit this template from the Settings menu.",
+                "firmwareJson": "Firmware JSON",
                 "packageNamePlaceholder": "Enter Package Name",
                 "packageVersionPlaceholder": "Enter Package Version",
                 "packageTypePlaceholder": "Select package type",

--- a/src/webui/public/locales/en/translations.json
+++ b/src/webui/public/locales/en/translations.json
@@ -158,6 +158,9 @@
                         "lastModifiedDate": "Human readable date timestamp",
                         "size": "File size in bytes",
                         "type": "Uploaded file type"
+                    },
+                    "deployment": {
+                        "id": "When deploying your package, this value will be replaced by the ID of your deployment"
                     }
                 }
             }

--- a/src/webui/src/components/pages/packages/flyouts/packageNew/packageNew.js
+++ b/src/webui/src/components/pages/packages/flyouts/packageNew/packageNew.js
@@ -4,6 +4,10 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { Link } from "react-router-dom";
 import {
+    Balloon,
+    BalloonPosition,
+} from "@microsoft/azure-iot-ux-fluent-controls/lib/components/Balloon/Balloon";
+import {
     packageTypeOptions,
     packagesEnum,
     configTypeOptions,
@@ -685,18 +689,7 @@ export class PackageNew extends LinkedComponent {
                                         )}
                                     </div>
                                 )}
-                                {uploadedFirmwareSuccessfully && (
-                                    <div>
-                                        <br />
-                                        <FormControl
-                                            link={this.packageJsonLink}
-                                            type="jsoninput"
-                                            height="550px"
-                                            theme={theme}
-                                            onChange={this.onJsonChange}
-                                        />
-                                    </div>
-                                )}
+                                {uploadedFirmwareSuccessfully && <br />}
                             </div>
                         )}
                         {packageFile && (
@@ -749,6 +742,31 @@ export class PackageNew extends LinkedComponent {
                                             {packageVersion}
                                         </FormLabel>
                                     )}
+                                </FormGroup>
+                            )}
+                        {!completedSuccessfully &&
+                            configType === "Firmware" &&
+                            uploadedFirmwareSuccessfully && (
+                                <FormGroup>
+                                    <FormLabel svg={svgs.info}>
+                                        <Balloon
+                                            position={BalloonPosition.Left}
+                                            tooltip={t(
+                                                "packages.flyouts.new.firmwareTemplateTip"
+                                            )}
+                                        >
+                                            {t(
+                                                "packages.flyouts.new.firmwareJson"
+                                            )}
+                                        </Balloon>
+                                    </FormLabel>
+                                    <FormControl
+                                        link={this.packageJsonLink}
+                                        type="jsoninput"
+                                        height="550px"
+                                        theme={theme}
+                                        onChange={this.onJsonChange}
+                                    />
                                 </FormGroup>
                             )}
                         <FormGroup>

--- a/src/webui/src/components/pages/packages/flyouts/packageNew/packageNew.js
+++ b/src/webui/src/components/pages/packages/flyouts/packageNew/packageNew.js
@@ -43,18 +43,8 @@ import uuid from "uuid/v4";
 const fileInputAccept = ".json,application/json",
     firmwareFileInputAccept =
         "*.zip,*.tar,*.bin,*.ipa,*.rar,*.gz,*.bz2,*.tgz,*.swu",
-    isVersionValid = (str) => /^(\d+\.)*(\d+)$/.test(str);
-
-const contentFormats = {
-    softwareConfig: {
-        desiredPropertiesKey: "properties.desired.softwareConfig",
-        versionKey: "version",
-    },
-    firmware: {
-        desiredPropertiesKey: "properties.desired.firmware",
-        versionKey: "fwVersion",
-    },
-};
+    isVersionValid = (str) => /^(\d+\.)*(\d+)$/.test(str),
+    firmwareJsonVariableReplace = /\$\{(blobData|packageFile)\.(.*)\}/;
 
 export class PackageNew extends LinkedComponent {
     constructor(props) {
@@ -73,40 +63,10 @@ export class PackageNew extends LinkedComponent {
             changesApplied: undefined,
             fileError: undefined,
             uploadedFirmwareSuccessfully: false,
-            packagepackageJsonContentFormat: contentFormats.softwareConfig,
             packageJson: {
-                jsObject: {
-                    id: "sampleConfigId",
-                    content: {
-                        deviceContent: {
-                            "properties.desired.softwareConfig": {
-                                softwareName: "Firmware",
-                                version: "1.0.0",
-                                softwareURL: "blob_uri",
-                                fileName: "filename",
-                                serialNumber: "",
-                                checkSum: "",
-                            },
-                        },
-                    },
-                    metrics: {
-                        queries: {
-                            current:
-                                "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Success'",
-                            applying:
-                                "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND ( properties.reported.softwareConfig.status='Downloading' OR properties.reported.softwareConfig.status='Verifying' OR properties.reported.softwareConfig.status='Applying')",
-                            rebooting:
-                                "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Rebooting'",
-                            error:
-                                "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.status='Error'",
-                            rolledback:
-                                "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.status='RolledBack'",
-                        },
-                    },
-                    targetCondition: "",
-                    priority: 20,
-                },
+                jsObject: {},
             },
+            firmwareTemplateVersionField: "",
         };
     }
 
@@ -124,7 +84,6 @@ export class PackageNew extends LinkedComponent {
                 packageVersion,
                 customConfigName,
                 fileError,
-                packageJson,
                 packageFile,
                 uploadedFirmwareSuccessfully,
                 tags,
@@ -138,45 +97,52 @@ export class PackageNew extends LinkedComponent {
         if (configType === "Firmware" && !uploadedFirmwareSuccessfully) {
             ConfigService.uploadFirmware(packageFile).subscribe(
                 (blobData) => {
-                    const packageJsonObject = packageJson.jsObject;
+                    ConfigService.getDefaultFirmwareSetting().subscribe(
+                        (firmwareTemplate) => {
+                            firmwareTemplate.jsObject.id =
+                                packageFile.name
+                                    .toLowerCase()
+                                    .replace(/[^a-z0-9[\]\-+%_*!']/gi, "_") +
+                                "-" +
+                                uuid();
+                            this.replaceFirmwareVariables(
+                                firmwareTemplate.jsObject,
+                                {
+                                    packageFile: packageFile,
+                                    blobData: blobData,
+                                }
+                            );
+                            this.replaceFirmwareVersion(
+                                firmwareTemplate.jsObject,
+                                packageVersion,
+                                firmwareTemplate.metadata.version
+                            );
 
-                    // Replace all invalid configuration id values
-                    packageJsonObject.id =
-                        packageFile.name
-                            .toLowerCase()
-                            .replace(/[^a-z0-9[\]\-+%_*!']/gi, "_") +
-                        "-" +
-                        uuid();
-                    packageJsonObject.content.deviceContent[
-                        "properties.desired.softwareConfig"
-                    ].fileName = packageFile.name;
-                    packageJsonObject.content.deviceContent[
-                        "properties.desired.softwareConfig"
-                    ].softwareURL = blobData.FileUri;
-                    packageJsonObject.content.deviceContent[
-                        "properties.desired.softwareConfig"
-                    ].checkSum = blobData.CheckSum;
-
-                    // Replace Configuration Ids in metrics
-                    for (const [key, value] of Object.entries(
-                        packageJsonObject.metrics.queries
-                    )) {
-                        packageJsonObject.metrics.queries[key] = value.replace(
-                            "firmware285",
-                            packageJsonObject.id
-                        );
-                    }
-
-                    this.setState({
-                        packageJson: packageJson,
-                        uploadedFirmwareSuccessfully: true,
-                        firmwarePackageName: packageFile.name,
-                        packageFile: dataURLtoFile(
-                            "data:application/json;base64," +
-                                btoa(JSON.stringify(packageJsonObject)),
-                            packageFile.name
-                        ),
-                    });
+                            this.setState({
+                                packageJson: {
+                                    jsObject: firmwareTemplate.jsObject,
+                                },
+                                firmwareTemplateVersionField:
+                                    firmwareTemplate.metadata.version,
+                                uploadedFirmwareSuccessfully: true,
+                                firmwarePackageName: packageFile.name,
+                                packageFile: dataURLtoFile(
+                                    "data:application/json;base64," +
+                                        btoa(
+                                            JSON.stringify(
+                                                firmwareTemplate.jsObject
+                                            )
+                                        ),
+                                    packageFile.name
+                                ),
+                            });
+                        },
+                        (error) => {
+                            this.setState({
+                                fileError: error,
+                            });
+                        }
+                    );
                 },
                 (error) => {
                     this.setState({
@@ -354,19 +320,6 @@ export class PackageNew extends LinkedComponent {
         link.set(link.value.filter((_, idx) => index !== idx));
     };
 
-    getContentFormatFromPackageJson = (packageJson) => {
-        const deviceContent = (packageJson.content || {}).deviceContent;
-        return deviceContent.hasOwnProperty(
-            contentFormats.softwareConfig.desiredPropertiesKey
-        )
-            ? contentFormats.softwareConfig
-            : deviceContent.hasOwnProperty(
-                  contentFormats.firmware.desiredPropertiesKey
-              )
-            ? contentFormats.firmware
-            : undefined;
-    };
-
     onJsonChange = (e) => {
         if (!e.target.value.error) {
             if (!e.target.value.jsObject) {
@@ -374,25 +327,9 @@ export class PackageNew extends LinkedComponent {
                 return;
             }
 
-            const changedPackageJsonObject = e.target.value.jsObject,
-                deviceContent = ((changedPackageJsonObject || {}).content || {})
-                    .deviceContent,
-                contentFormat = this.getContentFormatFromPackageJson(
-                    changedPackageJsonObject
-                );
+            const versionField = this.state.firmwareTemplateVersionField;
 
-            if (!contentFormat) {
-                e.target.value.error = true;
-                e.target.value.errorMessage = this.props.t(
-                    "packages.flyouts.new.validation.unsupportedProperty"
-                );
-                return;
-            }
-
-            const propertiesContent =
-                deviceContent[contentFormat.desiredPropertiesKey];
-
-            if (!propertiesContent.hasOwnProperty(contentFormat.versionKey)) {
+            if (!versionField) {
                 e.target.value.error = true;
                 e.target.value.errorMessage = this.props.t(
                     "packages.flyouts.new.validation.unsupportedVersionKey"
@@ -400,15 +337,20 @@ export class PackageNew extends LinkedComponent {
                 return;
             }
 
+            // loop through keys until you've taken the version key value
+            let version = e.target.value.jsObject;
+            versionField.split("//").forEach((childKey) => {
+                version = version[childKey];
+            });
+
             this.setState({
-                packageJsonContentFormat: contentFormat,
-                packageJson: e.target.value.json,
+                packageJson: e.target.value,
                 packageFile: dataURLtoFile(
                     "data:application/json;base64," +
                         btoa(JSON.stringify(e.target.value.jsObject)),
                     this.state.firmwarePackageName
                 ),
-                packageVersion: propertiesContent[contentFormat.versionKey],
+                packageVersion: version,
             });
         }
     };
@@ -418,19 +360,54 @@ export class PackageNew extends LinkedComponent {
     };
 
     packageVersionChange = ({ target: { value = {} } }) => {
-        const { packageJson, configType } = this.state;
+        const {
+            packageJson,
+            configType,
+            packageVersion,
+            firmwareTemplateVersionField,
+        } = this.state;
         let packageJsonObject = packageJson.jsObject;
 
         if (packageJsonObject && configType === "Firmware") {
-            // Replace version
-            packageJsonObject.content.deviceContent[
-                "properties.desired.softwareConfig"
-            ].version = value;
+            this.replaceFirmwareVersion(
+                packageJsonObject,
+                packageVersion,
+                firmwareTemplateVersionField
+            );
             this.setState({
                 packageJson: packageJson,
-                packageJsonObject: packageJson.jsObject,
             });
         }
+    };
+
+    replaceFirmwareVersion = (json, version, versionKey) => {
+        const versionKeySplit = versionKey.split("//");
+        let jsonChild = json;
+        versionKeySplit.forEach((key, idx) => {
+            if (idx === versionKeySplit.length - 1) {
+                jsonChild[key] = version;
+            } else {
+                jsonChild = jsonChild[key];
+            }
+        });
+    };
+
+    replaceFirmwareVariables = (json, varOptions) => {
+        for (const [key, value] of Object.entries(json)) {
+            if (value instanceof String) {
+                let varReplace = value.match(firmwareJsonVariableReplace);
+                if (varReplace) {
+                    let parent = varOptions[varReplace[1]];
+                    if (parent) {
+                        let child = parent[varReplace[2]];
+                        json[key] = child || value;
+                    }
+                }
+            } else if (value instanceof Object) {
+                this.replaceFirmwareVariables(value, varOptions);
+            }
+        }
+        return json;
     };
 
     render() {

--- a/src/webui/src/components/pages/packages/flyouts/packageNew/packageNew.js
+++ b/src/webui/src/components/pages/packages/flyouts/packageNew/packageNew.js
@@ -398,7 +398,9 @@ export class PackageNew extends LinkedComponent {
 
     replaceFirmwareVariables = (json, varOptions) => {
         for (const [key, value] of Object.entries(json)) {
-            if (value instanceof String) {
+            if (value instanceof Object) {
+                this.replaceFirmwareVariables(value, varOptions);
+            } else if (typeof value === "string" || value instanceof String) {
                 let varReplace = value.match(firmwareJsonVariableReplace);
                 if (varReplace) {
                     let parent = varOptions[varReplace[1]];
@@ -407,8 +409,6 @@ export class PackageNew extends LinkedComponent {
                         json[key] = child || value;
                     }
                 }
-            } else if (value instanceof Object) {
-                this.replaceFirmwareVariables(value, varOptions);
             }
         }
         return json;

--- a/src/webui/src/components/shell/flyouts/settings/firmwareVariableGrid.js
+++ b/src/webui/src/components/shell/flyouts/settings/firmwareVariableGrid.js
@@ -1,0 +1,58 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from "react";
+import {
+    PropertyGrid as Grid,
+    PropertyRow as Row,
+    PropertyCell as Cell,
+} from "components/shared";
+
+const key = "settingsFlyout.firmware.variables";
+
+class FirmwareVariableGrid extends React.Component {
+    render() {
+        const { t } = this.props,
+            variables = {
+                version: [""],
+                blobData: ["FileUri", "CheckSum"],
+                packageFile: [
+                    "name",
+                    "lastModified",
+                    "lastModifiedDate",
+                    "size",
+                    "type",
+                ],
+            },
+            variableRows = [];
+
+        Object.entries(variables).forEach((parent) => {
+            parent[1].forEach((child) => {
+                variableRows.push(
+                    <Row>
+                        <Cell>{parent[0]}</Cell>
+                        <Cell>{child}</Cell>
+                        <Cell>
+                            {t(
+                                `${key}.descriptions.${parent[0]}${
+                                    child ? "." + child : ""
+                                }`
+                            )}
+                        </Cell>
+                    </Row>
+                );
+            });
+        });
+
+        return (
+            <Grid>
+                <Row>
+                    <Cell>{t(`${key}.grid.parent`)}</Cell>
+                    <Cell>{t(`${key}.grid.child`)}</Cell>
+                    <Cell>{t(`${key}.grid.description`)}</Cell>
+                </Row>
+                {variableRows}
+            </Grid>
+        );
+    }
+}
+
+export default FirmwareVariableGrid;

--- a/src/webui/src/components/shell/flyouts/settings/firmwareVariableGrid.js
+++ b/src/webui/src/components/shell/flyouts/settings/firmwareVariableGrid.js
@@ -21,6 +21,7 @@ class FirmwareVariableGrid extends React.Component {
                     "size",
                     "type",
                 ],
+                deployment: ["id"],
             },
             variableRows = [];
 

--- a/src/webui/src/components/shell/flyouts/settings/settings.js
+++ b/src/webui/src/components/shell/flyouts/settings/settings.js
@@ -573,7 +573,7 @@ export class Settings extends LinkedComponent {
                                             <FormControl
                                                 link={this.firmwareJsonLink}
                                                 type="jsoninput"
-                                                height="50%"
+                                                height="100%"
                                                 theme={theme}
                                                 onChange={this.onFirmwareEdit}
                                             />

--- a/src/webui/src/components/shell/flyouts/settings/settings.js
+++ b/src/webui/src/components/shell/flyouts/settings/settings.js
@@ -22,6 +22,7 @@ import {
 
 import "./settings.scss";
 import { TenantService, ConfigService } from "services";
+import FirmwareVariableGrid from "./firmwareVariableGrid";
 
 const Section = Flyout.Section;
 
@@ -621,9 +622,21 @@ export class Settings extends LinkedComponent {
                                         </Btn>
                                     ) : (
                                         <div className="firmware-edit-container">
-                                            {t(
-                                                "settingsFlyout.firmware.variableSummary"
-                                            )}
+                                            <Section.Container closed={true}>
+                                                <Section.Header>
+                                                    {t(
+                                                        "settingsFlyout.firmware.variables.name"
+                                                    )}
+                                                </Section.Header>
+                                                <Section.Content>
+                                                    {t(
+                                                        "settingsFlyout.firmware.variables.summary"
+                                                    )}
+                                                    <FirmwareVariableGrid
+                                                        t={t}
+                                                    />
+                                                </Section.Content>
+                                            </Section.Container>
                                             <FormControl
                                                 link={this.firmwareJsonLink}
                                                 type="jsoninput"

--- a/src/webui/src/components/shell/flyouts/settings/settings.js
+++ b/src/webui/src/components/shell/flyouts/settings/settings.js
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+/* eslint-disable no-template-curly-in-string */
 
 import React from "react";
 import { Toggle } from "@microsoft/azure-iot-ux-fluent-controls/lib/components/Toggle";
@@ -37,10 +38,10 @@ const alertingIsPending = (jobState) => {
 
 const firmwareSettingErrorTypes = {
     noVersion: "settingsFlyout.firmware.error.noVersion",
-    uploadError: "settingsFlyout.firmware.error.upload",
+    upload: "settingsFlyout.firmware.error.upload",
     invalid: "settingsFlyout.firmware.error.invalid",
     unknown: "settingsFlyout.firmware.error.unknown",
-    retrievalError: "settingsFlyout.firmware.error.retrieval",
+    retrieval: "settingsFlyout.firmware.error.retrieval",
     doubleSlash: "settingsFlyout.firmware.error.doubleSlash",
     reserved: {
         id: "settingsFlyout.firmware.error.reserved.id",
@@ -314,8 +315,7 @@ export class Settings extends LinkedComponent {
             (error) => {
                 this.setState({
                     firmwareSettingPending: false,
-                    firmwareSettingError:
-                        firmwareSettingErrorTypes.retrievalError,
+                    firmwareSettingError: firmwareSettingErrorTypes.retrieval,
                 });
             }
         );
@@ -416,8 +416,7 @@ export class Settings extends LinkedComponent {
                 (error) => {
                     this.setState({
                         firmwareSettingPending: false,
-                        firmwareSettingError:
-                            firmwareSettingErrorTypes.uploadError,
+                        firmwareSettingError: firmwareSettingErrorTypes.upload,
                     });
                 }
             );
@@ -458,7 +457,10 @@ export class Settings extends LinkedComponent {
                 firmwareSettingError,
             } = this.state;
         this.applicationNameLink = this.linkTo("applicationName");
-        this.firmwareJsonLink = this.linkTo("firmwareJson");
+        this.firmwareJsonLink = this.linkTo("firmwareJson").check(
+            () => !firmwareSettingError,
+            (json) => json.errorMessage || t(firmwareSettingError)
+        );
         const hasChanged = logoFile !== undefined || applicationName !== "",
             hasSimulationChanged =
                 !getSimulationPending &&
@@ -612,14 +614,21 @@ export class Settings extends LinkedComponent {
                                 <Section.Content>
                                     {t("settingsFlyout.firmware.description")}
                                     {!firmwareEdit ? (
-                                        <Btn
-                                            type="button"
-                                            svg={svgs.edit}
-                                            onClick={this.enableFirmwareEdit}
-                                            className="firmware-edit-button"
-                                        >
-                                            {t("settingsFlyout.firmware.edit")}
-                                        </Btn>
+                                        <BtnToolbar>
+                                            <Btn
+                                                primary
+                                                type="button"
+                                                svg={svgs.edit}
+                                                onClick={
+                                                    this.enableFirmwareEdit
+                                                }
+                                                className="firmware-edit-button"
+                                            >
+                                                {t(
+                                                    "settingsFlyout.firmware.edit"
+                                                )}
+                                            </Btn>
+                                        </BtnToolbar>
                                     ) : (
                                         <div className="firmware-edit-container">
                                             <Section.Container closed={true}>
@@ -646,6 +655,7 @@ export class Settings extends LinkedComponent {
                                             />
                                             <BtnToolbar>
                                                 <Btn
+                                                    primary
                                                     type="button"
                                                     svg={svgs.checkmark}
                                                     onClick={
@@ -667,7 +677,7 @@ export class Settings extends LinkedComponent {
                                                 )}
                                                 <Btn
                                                     type="button"
-                                                    svg={svgs.x}
+                                                    svg={svgs.cancelX}
                                                     onClick={
                                                         this.disableFirmwareEdit
                                                     }
@@ -678,11 +688,6 @@ export class Settings extends LinkedComponent {
                                                     )}
                                                 </Btn>
                                             </BtnToolbar>
-                                        </div>
-                                    )}
-                                    {firmwareSettingError && (
-                                        <div className="firmware-setting-error-container">
-                                            {t(firmwareSettingError)}
                                         </div>
                                     )}
                                 </Section.Content>

--- a/src/webui/src/services/configService.js
+++ b/src/webui/src/services/configService.js
@@ -112,7 +112,7 @@ export class ConfigService {
         return HttpClient.post(
             `${ENDPOINT}solution-settings/defaultFirmware`,
             model
-        ).map(toSolutionSettingFirmwareModel);
+        );
     }
 
     static getDefaultFirmwareSetting() {

--- a/src/webui/src/services/configService.js
+++ b/src/webui/src/services/configService.js
@@ -206,10 +206,6 @@ export class ConfigService {
         return HttpClient.delete(`${ENDPOINT}packages/${id}`).map((_) => id);
     }
 
-    /*
-    a 404 is thrown by some device telemetry apis when a collection does not exist
-    for instances where this is the case, we want to catch this 404 and simply return no data instead
-    */
     static catch404(error, continueAs) {
         return error.status === 404
             ? Observable.of(continueAs)

--- a/src/webui/src/services/configService.js
+++ b/src/webui/src/services/configService.js
@@ -9,6 +9,7 @@ import {
     toDeviceGroupsModel,
     toSolutionSettingActionsModel,
     toSolutionSettingThemeModel,
+    toSolutionSettingFirmwareModel,
     toNewPackageRequestModel,
     toPackagesModel,
     toPackageModel,
@@ -105,6 +106,19 @@ export class ConfigService {
         return HttpClient.put(`${ENDPOINT}solution-settings/theme`, model).map(
             toSolutionSettingThemeModel
         );
+    }
+
+    static setDefaultFirmwareSetting(model) {
+        return HttpClient.post(
+            `${ENDPOINT}solution-settings/defaultFirmware`,
+            model
+        ).map(toSolutionSettingFirmwareModel);
+    }
+
+    static getDefaultFirmwareSetting() {
+        return HttpClient.get(
+            `${ENDPOINT}solution-settings/defaultFirmware`
+        ).map(toSolutionSettingFirmwareModel);
     }
 
     static getActionSettings() {

--- a/src/webui/src/services/configService.js
+++ b/src/webui/src/services/configService.js
@@ -16,6 +16,7 @@ import {
     toConfigTypesModel,
     toNewFirmwareUploadRequestModel,
     toFirmwareModel,
+    backupDefaultFirmwareModel,
 } from "./models";
 import { Observable } from "rxjs";
 
@@ -116,9 +117,9 @@ export class ConfigService {
     }
 
     static getDefaultFirmwareSetting() {
-        return HttpClient.get(
-            `${ENDPOINT}solution-settings/defaultFirmware`
-        ).map(toSolutionSettingFirmwareModel);
+        return HttpClient.get(`${ENDPOINT}solution-settings/defaultFirmware`)
+            .catch((error) => this.catch404(error, backupDefaultFirmwareModel))
+            .map(toSolutionSettingFirmwareModel);
     }
 
     static getActionSettings() {
@@ -203,5 +204,15 @@ export class ConfigService {
     /** Delete a package */
     static deletePackage(id) {
         return HttpClient.delete(`${ENDPOINT}packages/${id}`).map((_) => id);
+    }
+
+    /*
+    a 404 is thrown by some device telemetry apis when a collection does not exist
+    for instances where this is the case, we want to catch this 404 and simply return no data instead
+    */
+    static catch404(error, continueAs) {
+        return error.status === 404
+            ? Observable.of(continueAs)
+            : Observable.throw(error);
     }
 }

--- a/src/webui/src/services/models/configModels.js
+++ b/src/webui/src/services/models/configModels.js
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+/* eslint-disable no-template-curly-in-string */
 
 import update from "immutability-helper";
 import {

--- a/src/webui/src/services/models/configModels.js
+++ b/src/webui/src/services/models/configModels.js
@@ -71,11 +71,14 @@ export const prepareLogoResponse = ({ xhr, response }) => {
     return returnObj;
 };
 
-export const toSolutionSettingFirmwareModel = (response = {}) =>
-    camelCaseReshape(response, {
-        jsObject: "jsObject",
-        "metadata.version": "metadata.version",
-    });
+export const toSolutionSettingFirmwareModel = (model = {}) => {
+    return {
+        jsObject: model.jsObject,
+        metadata: {
+            version: model.metadata.version,
+        },
+    };
+};
 
 export const toSolutionSettingThemeModel = (response = {}) =>
     camelCaseReshape(response, {

--- a/src/webui/src/services/models/configModels.js
+++ b/src/webui/src/services/models/configModels.js
@@ -71,6 +71,12 @@ export const prepareLogoResponse = ({ xhr, response }) => {
     return returnObj;
 };
 
+export const toSolutionSettingFirmwareModel = (response = {}) =>
+    camelCaseReshape(response, {
+        jsObject: "jsObject",
+        "metadata.version": "metadata.version",
+    });
+
 export const toSolutionSettingThemeModel = (response = {}) =>
     camelCaseReshape(response, {
         description: "description",

--- a/src/webui/src/services/models/configModels.js
+++ b/src/webui/src/services/models/configModels.js
@@ -196,15 +196,15 @@ export const backupDefaultFirmwareModel = {
         metrics: {
             queries: {
                 current:
-                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Success'",
+                    "SELECT deviceId FROM devices WHERE configurations.[[${deployment.id}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Success'",
                 applying:
-                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND ( properties.reported.softwareConfig.status='Downloading' OR properties.reported.softwareConfig.status='Verifying' OR properties.reported.softwareConfig.status='Applying')",
+                    "SELECT deviceId FROM devices WHERE configurations.[[${deployment.id}]].status = 'Applied' AND ( properties.reported.softwareConfig.status='Downloading' OR properties.reported.softwareConfig.status='Verifying' OR properties.reported.softwareConfig.status='Applying')",
                 rebooting:
-                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Rebooting'",
+                    "SELECT deviceId FROM devices WHERE configurations.[[${deployment.id}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Rebooting'",
                 error:
-                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.status='Error'",
+                    "SELECT deviceId FROM devices WHERE configurations.[[${deployment.id}]].status = 'Applied' AND properties.reported.softwareConfig.status='Error'",
                 rolledback:
-                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.status='RolledBack'",
+                    "SELECT deviceId FROM devices WHERE configurations.[[${deployment.id}]].status = 'Applied' AND properties.reported.softwareConfig.status='RolledBack'",
             },
         },
         targetCondition: "",

--- a/src/webui/src/services/models/configModels.js
+++ b/src/webui/src/services/models/configModels.js
@@ -177,3 +177,40 @@ export const toPackageModel = (response = {}) => {
 };
 
 export const toConfigTypesModel = (response = {}) => getItems(response);
+
+export const backupDefaultFirmwareModel = {
+    jsObject: {
+        content: {
+            deviceContent: {
+                "properties.desired.softwareConfig": {
+                    softwareName: "Firmware",
+                    version: "${version}",
+                    softwareURL: "${blobData.FileUri}",
+                    fileName: "${packageFile.name}",
+                    serialNumber: "",
+                    checkSum: "${blobData.CheckSum}",
+                },
+            },
+        },
+        metrics: {
+            queries: {
+                current:
+                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Success'",
+                applying:
+                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND ( properties.reported.softwareConfig.status='Downloading' OR properties.reported.softwareConfig.status='Verifying' OR properties.reported.softwareConfig.status='Applying')",
+                rebooting:
+                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.version = properties.desired.softwareConfig.version AND properties.reported.softwareConfig.status='Rebooting'",
+                error:
+                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.status='Error'",
+                rolledback:
+                    "SELECT deviceId FROM devices WHERE configurations.[[{0}]].status = 'Applied' AND properties.reported.softwareConfig.status='RolledBack'",
+            },
+        },
+        targetCondition: "",
+        priority: 20,
+    },
+    metadata: {
+        version:
+            "content//deviceContent//properties.desired.softwareConfig//version",
+    },
+};

--- a/test/services/config/Services.Test/StorageTest.cs
+++ b/test/services/config/Services.Test/StorageTest.cs
@@ -205,14 +205,14 @@ namespace Mmm.Iot.Config.Services.Test
                 .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new ValueApiModel
                 {
-                    Data = JsonConvert.SerializeObject(new
+                    Data = JsonConvert.SerializeObject(new Theme
                     {
                         Name = name,
                         Description = description,
                     }),
                 });
 
-            var result = await this.storage.GetThemeAsync() as dynamic;
+            var result = await this.storage.GetThemeAsync();
 
             this.mockClient
                 .Verify(
@@ -233,7 +233,7 @@ namespace Mmm.Iot.Config.Services.Test
                 .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(new ResourceNotFoundException());
 
-            var result = await this.storage.GetThemeAsync() as dynamic;
+            var result = await this.storage.GetThemeAsync();
 
             this.mockClient
                 .Verify(
@@ -253,7 +253,7 @@ namespace Mmm.Iot.Config.Services.Test
             var name = this.rand.NextString();
             var description = this.rand.NextString();
 
-            var theme = new
+            var theme = new Theme
             {
                 Name = name,
                 Description = description,

--- a/test/services/config/WebService.Test/Controllers/SolutionSettingsControllerTest.cs
+++ b/test/services/config/WebService.Test/Controllers/SolutionSettingsControllerTest.cs
@@ -48,7 +48,7 @@ namespace Mmm.Iot.Config.WebService.Test.Controllers
 
             this.mockStorage
                 .Setup(x => x.GetThemeAsync())
-                .ReturnsAsync(new
+                .ReturnsAsync(new Theme
                 {
                     Name = name,
                     Description = description,
@@ -71,13 +71,13 @@ namespace Mmm.Iot.Config.WebService.Test.Controllers
 
             this.mockStorage
                 .Setup(x => x.SetThemeAsync(It.IsAny<object>()))
-                .ReturnsAsync(new
+                .ReturnsAsync(new Theme
                 {
                     Name = name,
                     Description = description,
                 });
 
-            var result = await this.controller.SetThemeAsync(new
+            var result = await this.controller.SetThemeAsync(new Theme
             {
                 Name = name,
                 Description = description,


### PR DESCRIPTION
This change rewrites some of our firmware package upload process in order to support multiple formats. Currently, we only loosely support two firmware json formats, and any deviation from those formats causes a problem when uploading. This change addresses this problem by adding a new solution-setting: `defaultFirmware`. The user has the ability to edit this setting from the settings menu on the webui. This setting is then used as initial template when uploading firmware files and editing the JSON before completing the package upload. I have added a backup/default template in the case that a tenant does not have this setting set.

[Dev Space](http://joe-default-firmware.s.default.reverse-proxy.cwnxvsfdmm.cus.azds.io/dashboard)
[AB#14154](https://dev.azure.com/3M-Bluebird/150135ff-890c-41c0-8f52-1cfcd5f891df/_workitems/edit/14154)