### PR TITLE
feat(webui): last refreshed date when alerting is turned off

### DIFF
--- a/src/webui/public/locales/en/translations.json
+++ b/src/webui/public/locales/en/translations.json
@@ -290,6 +290,7 @@
     },
     "dashboard": {
         "noData": "No data available",
+        "alertingTurnedOff": "Alerting is turned off",
         "panels": {
             "alerts": {
                 "header": "Alerts",

--- a/src/webui/src/components/pages/dashboard/dashboard.js
+++ b/src/webui/src/components/pages/dashboard/dashboard.js
@@ -186,6 +186,7 @@ export class Dashboard extends Component {
                                 TelemetryService.getAlerts(previousParams)
                             );
                         } else {
+                            this.setState({ analyticsIsPending: false });
                             return Observable.forkJoin([], [], [], []);
                         }
                     })
@@ -583,6 +584,7 @@ export class Dashboard extends Component {
                                 error={rulesError || analyticsError}
                                 t={t}
                                 deviceGroups={deviceGroups}
+                                isAlertingActive={alerting.isActive}
                             />
                         </Cell>
                         <Cell className="col-6">
@@ -615,6 +617,7 @@ export class Dashboard extends Component {
                                 theme={theme}
                                 colors={chartColorObjects}
                                 t={t}
+                                isAlertingActive={alerting.isActive}
                             />
                         </Cell>
                         {Config.showWalkthroughExamples && (

--- a/src/webui/src/components/pages/dashboard/panels/alerts/alertsPanel.js
+++ b/src/webui/src/components/pages/dashboard/panels/alerts/alertsPanel.js
@@ -52,7 +52,7 @@ export class AlertsPanel extends Component {
     };
 
     render() {
-        const { t, alerts, isPending, error } = this.props,
+        const { t, alerts, isPending, error, isAlertingActive } = this.props,
             gridProps = {
                 columnDefs: translateColumnDefs(t, this.columnDefs),
                 rowData: alerts,
@@ -71,9 +71,14 @@ export class AlertsPanel extends Component {
                 </PanelHeader>
                 <PanelContent>
                     <RulesGrid {...gridProps} />
-                    {!showOverlay && alerts.length === 0 && (
-                        <PanelMsg>{t("dashboard.noData")}</PanelMsg>
+                    {!isAlertingActive && (
+                        <PanelMsg>{t("dashboard.alertingTurnedOff")}</PanelMsg>
                     )}
+                    {isAlertingActive &&
+                        !showOverlay &&
+                        alerts.length === 0 && (
+                            <PanelMsg>{t("dashboard.noData")}</PanelMsg>
+                        )}
                 </PanelContent>
                 {showOverlay && (
                     <PanelOverlay>

--- a/src/webui/src/components/pages/dashboard/panels/analytics/analyticsPanel.js
+++ b/src/webui/src/components/pages/dashboard/panels/analytics/analyticsPanel.js
@@ -139,6 +139,7 @@ export class AnalyticsPanel extends Component {
                 topAlerts,
                 timeSeriesExplorerUrl,
                 error,
+                isAlertingActive,
             } = this.props,
             showOverlay = isPending && !criticalAlertsChange;
         return (
@@ -180,7 +181,11 @@ export class AnalyticsPanel extends Component {
                             )}
                         </div>
                     </div>
-                    {!showOverlay &&
+                    {!isAlertingActive && (
+                        <PanelMsg>{t("dashboard.alertingTurnedOff")}</PanelMsg>
+                    )}
+                    {isAlertingActive &&
+                        !showOverlay &&
                         !topAlerts.length &&
                         !Object.keys(alertsPerDeviceId).length && (
                             <PanelMsg>{t("dashboard.noData")}</PanelMsg>


### PR DESCRIPTION
Changes include 

1. Displaying last refreshed datetime when Alerting is turned off
2. Displaying 'Alerting is turned off' message in Alerts and Analytics dashboard panels when Alerting is turned off