### PR TITLE
prevent premature cleanup

### DIFF
--- a/pipelines/ci/test.yaml
+++ b/pipelines/ci/test.yaml
@@ -765,6 +765,7 @@ stages:
     dependsOn:
       - functionalTest
       - enumerateDependencies
+      - deployServices
     condition: and(succeededOrFailed(), eq(variables['runCleanupStage'], 'true'))
     jobs:
       - job: getPipelineVariables


### PR DESCRIPTION
HELM Charts are getting removed while Deploy Services are running, leading to random issues.