### PR TITLE
feat(webui & service): Implementation of deployment history at device level

### DIFF
--- a/src/services/common/Services/Helpers/QueryBuilder.cs
+++ b/src/services/common/Services/Helpers/QueryBuilder.cs
@@ -127,6 +127,26 @@ namespace Mmm.Iot.Common.Services.Helpers
             return new SqlQuerySpec(queryBuilder.ToString(), sqlParameterCollection);
         }
 
+        public static SqlQuerySpec GetDeviceDocumentsSqlByKey(
+            string key,
+            string keyProperty)
+        {
+            var sqlParameterCollection = new SqlParameterCollection();
+            ValidateInput(ref key);
+            ValidateInput(ref keyProperty);
+
+            var queryBuilder = new StringBuilder("SELECT * FROM c");
+
+            if (!string.IsNullOrEmpty(key))
+            {
+                queryBuilder.Append($" WHERE c[@keyProperty] = \"{keyProperty}\"");
+                sqlParameterCollection.Add(new SqlParameter { Name = "@keyProperty", Value = key });
+            }
+
+            queryBuilder.Append(" ORDER BY c[\"_ts\"] DESC");
+            return new SqlQuerySpec(queryBuilder.ToString(), sqlParameterCollection);
+        }
+
         public static SqlQuerySpec GetCountSql(
         string schemaName,
         string byId,

--- a/src/services/iothub-manager/Services/Deployments.cs
+++ b/src/services/iothub-manager/Services/Deployments.cs
@@ -7,11 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Server.HttpSys;
 using Microsoft.Azure.Devices;
-using Microsoft.Azure.Devices.Shared;
-using Microsoft.Azure.Documents;
 using Microsoft.Extensions.Logging;
 using Mmm.Iot.Common.Services.Config;
 using Mmm.Iot.Common.Services.Exceptions;
@@ -284,10 +280,13 @@ namespace Mmm.Iot.IoTHubManager.Services
                         existingDeployment.DeploymentMetrics = currentDeployment.DeploymentMetrics;
                     }
 
-                    deviceTwins = await this.GetDeviceProperties(currentDeployment.DeploymentMetrics.DeviceStatuses.Keys);
-                    if (currentDeployment.PackageType == PackageType.EdgeManifest)
+                    if (currentDeployment != null && currentDeployment.DeploymentMetrics != null && currentDeployment.DeploymentMetrics.DeviceStatuses != null && currentDeployment.DeploymentMetrics.DeviceStatuses.Keys.Count > 0)
                     {
-                        moduleTwins = await this.GetDeviceProperties(currentDeployment.DeploymentMetrics.DeviceStatuses.Keys, PackageType.EdgeManifest);
+                        deviceTwins = await this.GetDeviceProperties(currentDeployment.DeploymentMetrics.DeviceStatuses.Keys);
+                        if (currentDeployment.PackageType == PackageType.EdgeManifest)
+                        {
+                            moduleTwins = await this.GetDeviceProperties(currentDeployment.DeploymentMetrics.DeviceStatuses.Keys, PackageType.EdgeManifest);
+                        }
                     }
                 }
 

--- a/src/services/iothub-manager/Services/Deployments.cs
+++ b/src/services/iothub-manager/Services/Deployments.cs
@@ -46,6 +46,7 @@ namespace Mmm.Iot.IoTHubManager.Services
         private const string DeploymentDevicePropertiesCollection = "deploymentdevices-{0}";
         private const string DeploymentEdgeModulePropertiesCollection = "deploymentedgemodules-{0}";
         private const string DeploymentHistoryPropertiesCollection = "deploymentHistory-{0}_{1}";
+        private const string DeploymentModuleHistoryPropertiesCollection = "deploymentModulesHistory-{0}_{1}";
         private const string DeleteTag = "reserved.isDeleted";
         private const string LatestTag = "reserved.latest";
         private const string InActiveTag = "reserved.inactive";
@@ -982,7 +983,7 @@ namespace Mmm.Iot.IoTHubManager.Services
                             {
                                 NullValueHandling = NullValueHandling.Ignore,
                             });
-                        await this.client.UpdateAsync(string.Format(DeploymentHistoryPropertiesCollection, deploymentId, Guid.NewGuid().ToString()), $"{moduleTwin.DeviceId}-{this.RemoveSpecialCharacters(moduleTwin.ModuleId)}", archiveModuleTwinValue, null);
+                        await this.client.UpdateAsync(string.Format(DeploymentModuleHistoryPropertiesCollection, deploymentId, Guid.NewGuid().ToString()), $"{moduleTwin.DeviceId}-{this.RemoveSpecialCharacters(moduleTwin.ModuleId)}", archiveModuleTwinValue, null);
                     }
                 }
             }

--- a/src/services/iothub-manager/Services/Devices.cs
+++ b/src/services/iothub-manager/Services/Devices.cs
@@ -8,13 +8,18 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices;
 using Microsoft.Azure.Devices.Shared;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using Mmm.Iot.Common.Services.Config;
 using Mmm.Iot.Common.Services.Exceptions;
 using Mmm.Iot.Common.Services.External.AsaManager;
+using Mmm.Iot.Common.Services.External.CosmosDb;
+using Mmm.Iot.Common.Services.Helpers;
 using Mmm.Iot.Common.Services.Models;
 using Mmm.Iot.IoTHubManager.Services.Extensions;
 using Mmm.Iot.IoTHubManager.Services.Helpers;
 using Mmm.Iot.IoTHubManager.Services.Models;
+using Mmm.Iot.StorageAdapter.Services.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using AuthenticationType = Mmm.Iot.IoTHubManager.Services.Models.AuthenticationType;
@@ -32,12 +37,14 @@ namespace Mmm.Iot.IoTHubManager.Services
         private readonly ITenantConnectionHelper tenantConnectionHelper;
         private readonly IAsaManagerClient asaManager;
         private readonly IDeviceQueryCache deviceQueryCache;
+        private readonly IStorageClient storageClient;
 
         public Devices(
             AppConfig config,
             ITenantConnectionHelper tenantConnectionHelper,
             IAsaManagerClient asaManagerClient,
-            IDeviceQueryCache deviceQueryCache)
+            IDeviceQueryCache deviceQueryCache,
+            IStorageClient storageClient)
         {
             if (config == null)
             {
@@ -47,17 +54,44 @@ namespace Mmm.Iot.IoTHubManager.Services
             this.tenantConnectionHelper = tenantConnectionHelper;
             this.asaManager = asaManagerClient;
             this.deviceQueryCache = deviceQueryCache;
+            this.storageClient = storageClient;
         }
 
         public Devices(
             ITenantConnectionHelper tenantConnectionHelper,
             string ioTHubHostName,
             IAsaManagerClient asaManagerClient,
-            IDeviceQueryCache deviceQueryCache)
+            IDeviceQueryCache deviceQueryCache,
+            IStorageClient storageClient)
         {
             this.tenantConnectionHelper = tenantConnectionHelper ?? throw new ArgumentNullException("tenantConnectionHelper " + ioTHubHostName);
             this.asaManager = asaManagerClient;
             this.deviceQueryCache = deviceQueryCache;
+            this.storageClient = storageClient;
+        }
+
+        public virtual string DocumentDataType
+        {
+            get
+            {
+                return "pcs";
+            }
+        }
+
+        public virtual string DocumentDatabaseSuffix
+        {
+            get
+            {
+                return "storage";
+            }
+        }
+
+        public virtual string DocumentDbDatabaseId
+        {
+            get
+            {
+                return $"{this.DocumentDataType}-{this.DocumentDatabaseSuffix}";
+            }
         }
 
         // Ping the registry to see if the connection is healthy
@@ -245,6 +279,31 @@ namespace Mmm.Iot.IoTHubManager.Services
             var result = twins.Result.Select(twin => new TwinServiceModel(twin)).ToList();
 
             return new TwinServiceListModel(result, twins.ContinuationToken);
+        }
+
+        public async Task<TwinServiceListModel> GetDeploymentHistoryAsync(string deviceId, string tenantId)
+        {
+            var sql = QueryBuilder.GetDeviceDocumentsSqlByKey("Key", deviceId);
+
+            FeedOptions queryOptions = new FeedOptions
+            {
+                EnableCrossPartitionQuery = true,
+                EnableScanInQuery = true,
+            };
+            List<Document> docs = await this.storageClient.QueryDocumentsAsync(
+                this.DocumentDbDatabaseId,
+                $"{this.DocumentDataType}-{tenantId}",
+                queryOptions,
+                sql,
+                0,
+                1000);
+
+            var result = docs == null ?
+                new List<TwinServiceModel>() :
+                docs
+                    .Select(doc => new ValueServiceModel(doc)).Select(x => JsonConvert.DeserializeObject<TwinServiceModel>(x.Data))
+                    .ToList();
+            return new TwinServiceListModel(result, null);
         }
 
         private async Task<ResultWithContinuationToken<List<Twin>>> GetTwinByQueryAsync(

--- a/src/services/iothub-manager/Services/Helpers/ConfigurationsHelper.cs
+++ b/src/services/iothub-manager/Services/Helpers/ConfigurationsHelper.cs
@@ -43,7 +43,7 @@ namespace Mmm.Iot.IoTHubManager.Services.Helpers
                 throw new InvalidInputException("Deployment type does not match with package contents.");
             }
 
-            var deploymentId = string.IsNullOrWhiteSpace(model.Id) ? Guid.NewGuid().ToString().ToLower() : model.Id;
+            var deploymentId = Guid.NewGuid().ToString().ToLower();
             var configuration = new Configuration(deploymentId);
             configuration.Content = packageConfiguration.Content;
 

--- a/src/services/iothub-manager/Services/IDeployments.cs
+++ b/src/services/iothub-manager/Services/IDeployments.cs
@@ -30,5 +30,7 @@ namespace Mmm.Iot.IoTHubManager.Services
         Task<DeviceServiceListModel> GetDeviceListAsync(string deploymentId, string query, bool isLatest);
 
         Task<List<DeviceDeploymentStatusServiceModel>> GetDeploymentStatusReport(string id, bool isLatest = true);
+
+        Task<TwinServiceListModel> GetModulesListAsync(string deploymentId, string query, bool isLatest);
     }
 }

--- a/src/services/iothub-manager/Services/IDevices.cs
+++ b/src/services/iothub-manager/Services/IDevices.cs
@@ -25,5 +25,7 @@ namespace Mmm.Iot.IoTHubManager.Services
         Task<TwinServiceModel> GetModuleTwinAsync(string deviceId, string moduleId);
 
         Task<TwinServiceListModel> GetModuleTwinsByQueryAsync(string query, string continuationToken);
+
+        Task<TwinServiceListModel> GetDeploymentHistoryAsync(string deviceId, string tenantId);
     }
 }

--- a/src/services/iothub-manager/Services/IDevices.cs
+++ b/src/services/iothub-manager/Services/IDevices.cs
@@ -27,5 +27,7 @@ namespace Mmm.Iot.IoTHubManager.Services
         Task<TwinServiceListModel> GetModuleTwinsByQueryAsync(string query, string continuationToken);
 
         Task<TwinServiceListModel> GetDeploymentHistoryAsync(string deviceId, string tenantId);
+
+        Task<DeviceServiceListModel> GetDeviceListAsync(string query, string continuationToken);
     }
 }

--- a/src/services/iothub-manager/Services/Models/TwinServiceListModel.cs
+++ b/src/services/iothub-manager/Services/Models/TwinServiceListModel.cs
@@ -8,6 +8,10 @@ namespace Mmm.Iot.IoTHubManager.Services.Models
 {
     public class TwinServiceListModel
     {
+        public TwinServiceListModel()
+        {
+        }
+
         public TwinServiceListModel(IEnumerable<TwinServiceModel> twins, string continuationToken = null)
         {
             this.ContinuationToken = continuationToken;

--- a/src/services/iothub-manager/Services/Services.csproj
+++ b/src/services/iothub-manager/Services/Services.csproj
@@ -9,5 +9,6 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\common\Services\Services.csproj" />
+        <ProjectReference Include="..\..\storage-adapter\Services\Services.csproj" />
     </ItemGroup>
 </Project>

--- a/src/services/iothub-manager/WebService/Controllers/DeploymentsController.cs
+++ b/src/services/iothub-manager/WebService/Controllers/DeploymentsController.cs
@@ -124,6 +124,13 @@ namespace Mmm.Iot.IoTHubManager.WebService.Controllers
             return new DeviceListApiModel(await this.deployments.GetDeviceListAsync(id, query, isLatest));
         }
 
+        [HttpPost("Modules/{id}")]
+        [Authorize("ReadAll")]
+        public async Task<TwinPropertiesListApiModel> GetDeploymentImpactedEdgeModules(string id, [FromBody] string query, [FromQuery] bool isLatest = false)
+        {
+            return new TwinPropertiesListApiModel(await this.deployments.GetModulesListAsync(id, query, isLatest));
+        }
+
         [HttpGet("Report/{id}")]
         [Authorize("ReadAll")]
         public async Task<IActionResult> ExportDeploymentReport(string id, [FromQuery] bool isLatest = true)

--- a/src/services/iothub-manager/WebService/Controllers/DevicesController.cs
+++ b/src/services/iothub-manager/WebService/Controllers/DevicesController.cs
@@ -55,6 +55,13 @@ namespace Mmm.Iot.IoTHubManager.WebService.Controllers
             return new DeviceListApiModel(await this.devices.GetListAsync(query, continuationToken));
         }
 
+        [HttpGet("deploymentHistory/{id}")]
+        [Authorize("ReadAll")]
+        public async Task<TwinPropertiesListApiModel> GetDeviceDeploymentAsync(string id)
+        {
+            return new TwinPropertiesListApiModel(await this.devices.GetDeploymentHistoryAsync(id, this.GetTenantId()));
+        }
+
         [HttpGet("{id}")]
         [Authorize("ReadAll")]
         public async Task<DeviceRegistryApiModel> GetDeviceAsync(string id)

--- a/src/webui/public/locales/en/translations.json
+++ b/src/webui/public/locales/en/translations.json
@@ -477,6 +477,14 @@
                     "action": "Action",
                     "property": "Property",
                     "value": "Value"
+                },
+                "deviceDeployments": {
+                    "title": "Device Deployments",
+                    "description": "Deployment History of device",
+                    "noneExist": "No history present for this device",
+                    "firmwareVersion" : "Firmware Version",
+                    "startDate": "Start Date Time",
+                    "endDate": "End Date Time"
                 }
             },
             "delete": {

--- a/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.js
+++ b/src/webui/src/components/pages/devices/flyouts/deviceDetails/deviceDetails.js
@@ -10,7 +10,7 @@ import {
 } from "@microsoft/azure-iot-ux-fluent-controls/lib/components/Balloon/Balloon";
 
 import Config from "app.config";
-import { TelemetryService } from "services";
+import { TelemetryService, IoTHubManagerService } from "services";
 import { DeviceIcon } from "./deviceIcon";
 import { RulesGrid, rulesColumnDefs } from "components/pages/rules/rulesGrid";
 import {
@@ -83,6 +83,7 @@ export class DeviceDetails extends Component {
             showRawMessage: false,
             currentModuleStatus: undefined,
             deviceUploads: undefined,
+            deviceDeployments: undefined,
         };
         this.baseState = this.state;
         this.columnDefs = [
@@ -119,6 +120,7 @@ export class DeviceDetails extends Component {
             deviceId = device.id;
         this.fetchAlerts(deviceId);
         this.fetchDeviceUploads(deviceId);
+        this.fetchDeviceDeployments(deviceId);
 
         const [hours = 0, minutes = 0, seconds = 0] = interval
                 .split(":")
@@ -285,6 +287,22 @@ export class DeviceDetails extends Component {
         });
     };
 
+    fetchDeviceDeployments = (deviceId) => {
+        IoTHubManagerService.getDeploymentHistoryForSelectedDevice(
+            deviceId
+        ).subscribe((deviceDeployments) => {
+            var filteredDeployments = [];
+            deviceDeployments.forEach((deployment) => {
+                if (deployment) {
+                    filteredDeployments.push(deployment);
+                }
+            });
+            this.setState({
+                deviceDeployments: filteredDeployments,
+            });
+        });
+    };
+
     downloadFile = (relativePath, fileName) => {
         TelemetryService.getDeviceUploadsFileContent(relativePath).subscribe(
             (response) => {
@@ -334,6 +352,7 @@ export class DeviceDetails extends Component {
             tags = Object.entries(device.tags || {}),
             properties = Object.entries(device.properties || {}),
             deviceUploads = this.state.deviceUploads || [],
+            deviceDeployments = this.state.deviceDeployments || [],
             moduleQuerySuccessful =
                 currentModuleStatus &&
                 currentModuleStatus !== {} &&
@@ -969,6 +988,72 @@ export class DeviceDetails extends Component {
                                                                             )
                                                                         }
                                                                     ></Btn>
+                                                                </Cell>
+                                                            </Row>
+                                                        )
+                                                    )}
+                                                </GridBody>
+                                            </Grid>
+                                        )}
+                                    </div>
+                                </Section.Content>
+                            </Section.Container>
+                            <Section.Container>
+                                <Section.Header>
+                                    {t(
+                                        "devices.flyouts.details.deviceDeployments.title"
+                                    )}
+                                </Section.Header>
+                                <Section.Content>
+                                    <SectionDesc>
+                                        {t(
+                                            "devices.flyouts.details.deviceDeployments.description"
+                                        )}
+                                    </SectionDesc>
+                                    <div className="device-details-deviceDeployments-contentbox">
+                                        {deviceDeployments.length === 0 &&
+                                            t(
+                                                "devices.flyouts.details.deviceDeployments.noneExist"
+                                            )}
+                                        {deviceDeployments.length > 0 && (
+                                            <Grid className="device-details-deviceDeployments">
+                                                <GridHeader>
+                                                    <Row>
+                                                        <Cell className="col-4">
+                                                            {t(
+                                                                "devices.flyouts.details.deviceDeployments.firmwareVersion"
+                                                            )}
+                                                        </Cell>
+                                                        <Cell className="col-4">
+                                                            {t(
+                                                                "devices.flyouts.details.deviceDeployments.startDate"
+                                                            )}
+                                                        </Cell>
+                                                        <Cell className="col-4">
+                                                            {t(
+                                                                "devices.flyouts.details.deviceDeployments.endDate"
+                                                            )}
+                                                        </Cell>
+                                                    </Row>
+                                                </GridHeader>
+                                                <GridBody>
+                                                    {deviceDeployments.map(
+                                                        (deployment, idx) => (
+                                                            <Row key={idx}>
+                                                                <Cell className="col-4">
+                                                                    {
+                                                                        deployment.firmwareVersion
+                                                                    }
+                                                                </Cell>
+                                                                <Cell className="col-4">
+                                                                    {formatTime(
+                                                                        deployment.startTime
+                                                                    )}
+                                                                </Cell>
+                                                                <Cell className="col-4">
+                                                                    {formatTime(
+                                                                        deployment.endTime
+                                                                    )}
                                                                 </Cell>
                                                             </Row>
                                                         )

--- a/src/webui/src/services/iotHubManagerService.js
+++ b/src/webui/src/services/iotHubManagerService.js
@@ -16,6 +16,7 @@ import {
     toDeploymentsModel,
     toDeploymentRequestModel,
     toEdgeAgentsModel,
+    toDevicesDeploymentHistoryModel,
 } from "./models";
 
 const ENDPOINT = Config.serviceUrls.iotHubManager;
@@ -175,5 +176,11 @@ export class IoTHubManagerService {
             { responseType: "blob", timeout: 120000 }
         );
         return response;
+    }
+
+    static getDeploymentHistoryForSelectedDevice(deviceId) {
+        return HttpClient.get(
+            `${ENDPOINT}devices/deploymentHistory/${deviceId}`
+        ).map(toDevicesDeploymentHistoryModel);
     }
 }

--- a/src/webui/src/services/iotHubManagerService.js
+++ b/src/webui/src/services/iotHubManagerService.js
@@ -115,14 +115,16 @@ export class IoTHubManagerService {
     static getDevicesByQueryForDeployment(id, query, isLatest) {
         return HttpClient.post(
             `${ENDPOINT}deployments/devices/${id}?isLatest=${isLatest}`,
-            query
+            query,
+            { timeout: 120000 }
         ).map(toDevicesModel);
     }
 
     static getModulesByQueryForDeployment(id, query, isLatest) {
         return HttpClient.post(
             `${ENDPOINT}deployments/modules/${id}?isLatest=${isLatest}`,
-            query
+            query,
+            { timeout: 120000 }
         ).map(toEdgeAgentsModel);
     }
 
@@ -130,14 +132,17 @@ export class IoTHubManagerService {
     static createDeployment(deploymentModel) {
         return HttpClient.post(
             `${ENDPOINT}deployments`,
-            toDeploymentRequestModel(deploymentModel)
+            toDeploymentRequestModel(deploymentModel),
+            { timeout: 120000 }
         ).map(toDeploymentModel);
     }
 
     /** Delete a deployment */
     static deleteDeployment(id, isDelete = true) {
         return HttpClient.delete(
-            `${ENDPOINT}deployments/${id}?isDelete=${isDelete}`
+            `${ENDPOINT}deployments/${id}?isDelete=${isDelete}`,
+            {},
+            { timeout: 120000 }
         ).map(() => id);
     }
 

--- a/src/webui/src/services/iotHubManagerService.js
+++ b/src/webui/src/services/iotHubManagerService.js
@@ -16,6 +16,7 @@ import {
     toDeploymentsModel,
     toDeploymentRequestModel,
     toEdgeAgentsModel,
+    toDevicesDeploymentHistoryModel,
 } from "./models";
 
 const ENDPOINT = Config.serviceUrls.iotHubManager;
@@ -117,6 +118,13 @@ export class IoTHubManagerService {
             `${ENDPOINT}deployments/devices/${id}?isLatest=${isLatest}`,
             query
         ).map(toDevicesModel);
+    }
+
+    static getDeploymentHistoryForSelectedDevice(deviceId) {
+        debugger;
+        return HttpClient.get(
+            `${ENDPOINT}devices/deploymentHistory/${deviceId}`
+        ).map(toDevicesDeploymentHistoryModel);
     }
 
     /** Create a deployment */

--- a/src/webui/src/services/iotHubManagerService.js
+++ b/src/webui/src/services/iotHubManagerService.js
@@ -16,7 +16,6 @@ import {
     toDeploymentsModel,
     toDeploymentRequestModel,
     toEdgeAgentsModel,
-    toDevicesDeploymentHistoryModel,
 } from "./models";
 
 const ENDPOINT = Config.serviceUrls.iotHubManager;
@@ -120,11 +119,11 @@ export class IoTHubManagerService {
         ).map(toDevicesModel);
     }
 
-    static getDeploymentHistoryForSelectedDevice(deviceId) {
-        debugger;
-        return HttpClient.get(
-            `${ENDPOINT}devices/deploymentHistory/${deviceId}`
-        ).map(toDevicesDeploymentHistoryModel);
+    static getModulesByQueryForDeployment(id, query, isLatest) {
+        return HttpClient.post(
+            `${ENDPOINT}deployments/modules/${id}?isLatest=${isLatest}`,
+            query
+        ).map(toEdgeAgentsModel);
     }
 
     /** Create a deployment */

--- a/src/webui/src/services/models/iotHubManagerModels.js
+++ b/src/webui/src/services/models/iotHubManagerModels.js
@@ -4,6 +4,7 @@ import update from "immutability-helper";
 import dot from "dot-object";
 import { camelCaseReshape, getItems, float } from "utilities";
 import uuid from "uuid/v4";
+import { map } from "rxjs/operator/map";
 
 // Contains methods for converting service response
 // object to UI friendly objects
@@ -288,3 +289,18 @@ export const toEdgeAgentModel = (edgeAgent = {}) =>
 
 export const toEdgeAgentsModel = (response = []) =>
     getItems(response).map(toEdgeAgentModel);
+
+export const toDevicesDeploymentHistoryModel = (response = []) =>
+    getItems(response).map(toDeviceDeploymentHistoryModel);
+
+export const toDeviceDeploymentHistoryModel = (twinServiceModel = {}) => {
+    if (twinServiceModel.Reported && twinServiceModel.Reported.firmware) {
+        var modelData = {
+            firmwareVersion:
+                twinServiceModel.Reported.firmware.currentFwVersion,
+            startTime: twinServiceModel.Reported.firmware.lastFwUpdateStartTime,
+            endTime: twinServiceModel.Reported.firmware.lastFwUpdateEndTime,
+        };
+        return modelData;
+    }
+};

--- a/src/webui/src/services/models/iotHubManagerModels.js
+++ b/src/webui/src/services/models/iotHubManagerModels.js
@@ -4,7 +4,6 @@ import update from "immutability-helper";
 import dot from "dot-object";
 import { camelCaseReshape, getItems, float } from "utilities";
 import uuid from "uuid/v4";
-import { map } from "rxjs/operator/map";
 
 // Contains methods for converting service response
 // object to UI friendly objects

--- a/src/webui/src/store/reducers/deploymentsReducer.js
+++ b/src/webui/src/store/reducers/deploymentsReducer.js
@@ -28,9 +28,9 @@ import { packagesEnum } from "services/models";
 
 // ========================= Epics - START
 const handleError = (fromAction) => (error) =>
-    Observable.of(
-        redux.actions.registerError(fromAction.type, { error, fromAction })
-    ),
+        Observable.of(
+            redux.actions.registerError(fromAction.type, { error, fromAction })
+        ),
     getDeployedDeviceIds = (payload) => {
         return Object.keys(dot.pick("deviceStatuses", payload))
             .map((id) => `'${id}'`)
@@ -105,7 +105,8 @@ export const epics = createEpicScenario({
                         getDeployedDeviceIds(fromAction.payload)
                     ),
                     fromAction.payload.isLatest
-                ))
+                )
+            )
                 .map(
                     toActionCreator(
                         redux.actions.updateDeployedDevices,
@@ -217,8 +218,8 @@ const deploymentSchema = new schema.Entity("deployments"),
         { payload: [modules, devices], fromAction }
     ) => {
         const normalizedDevices =
-            normalize(devices, deployedDevicesListSchema).entities
-                .deployedDevices || {},
+                normalize(devices, deployedDevicesListSchema).entities
+                    .deployedDevices || {},
             normalizedModules =
                 normalize(modules, deployedDevicesListSchema).entities
                     .deployedDevices || {},
@@ -242,8 +243,8 @@ const deploymentSchema = new schema.Entity("deployments"),
     },
     updateADMDeployedDevicesReducer = (state, { payload, fromAction }) => {
         const normalizedDevices =
-            normalize(payload, deployedDevicesListSchema).entities
-                .deployedDevices || {},
+                normalize(payload, deployedDevicesListSchema).entities
+                    .deployedDevices || {},
             deployedDevices = Object.keys(normalizedDevices).reduce(
                 (acc, deviceId) => ({
                     ...acc,

--- a/test/services/iothub-manager/Services.Test/DevicesTest.cs
+++ b/test/services/iothub-manager/Services.Test/DevicesTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.Devices;
 using Microsoft.Azure.Devices.Shared;
 using Mmm.Iot.Common.Services.Exceptions;
 using Mmm.Iot.Common.Services.External.AsaManager;
+using Mmm.Iot.Common.Services.External.CosmosDb;
 using Mmm.Iot.Common.TestHelpers;
 using Mmm.Iot.IoTHubManager.Services.Helpers;
 using Mmm.Iot.IoTHubManager.Services.Models;
@@ -27,6 +28,7 @@ namespace Mmm.Iot.IoTHubManager.Services.Test
         private readonly Mock<ITenantConnectionHelper> mockTenantHelper;
         private readonly Mock<IAsaManagerClient> mockAsaManager;
         private readonly Mock<IDeviceQueryCache> mockCache;
+        private readonly Mock<IStorageClient> mockStorageClient;
 
         public DevicesTest()
         {
@@ -51,8 +53,9 @@ namespace Mmm.Iot.IoTHubManager.Services.Test
                         It.IsAny<string>(),
                         It.IsAny<string>(),
                         It.IsAny<DeviceQueryCacheResultServiceModel>()));
+            this.mockStorageClient = new Mock<IStorageClient>();
 
-            this.devices = new Devices(this.mockTenantHelper.Object, this.ioTHubHostName, this.mockAsaManager.Object, this.mockCache.Object);
+            this.devices = new Devices(this.mockTenantHelper.Object, this.ioTHubHostName, this.mockAsaManager.Object, this.mockCache.Object, this.mockStorageClient.Object);
         }
 
         [Theory]


### PR DESCRIPTION
Hi Team,

This PR includes the changes of implementation of deployment history at device level. Below are the changes made as part of this user story.

- Updated the saving logic of device twins including the edge devices
- Added Deployment History section in Device details flyout