### PR TITLE
fix(webui): Show tooltip on hover over device group name

### DIFF
--- a/src/webui/src/components/shell/flyouts/manageDeviceGroups/views/deviceGroups.js
+++ b/src/webui/src/components/shell/flyouts/manageDeviceGroups/views/deviceGroups.js
@@ -152,6 +152,7 @@ export class DeviceGroups extends React.Component {
                                             onClick={onEditDeviceGroup(
                                                 deviceGroup
                                             )}
+                                            title={deviceGroup.displayName}
                                         >
                                             {deviceGroup.displayName}
                                         </div>


### PR DESCRIPTION
Made changes to show title on hover over device group name in device group list in manage device group flyout.