### PR TITLE
fix(webui): build failure

### DIFF
--- a/src/webui/package.json
+++ b/src/webui/package.json
@@ -31,7 +31,7 @@
         "react-dom": "16.6.3",
         "react-dom-factories": "1.0.2",
         "react-i18next": "8.3.8",
-        "react-json-editor-ajrm": "^2.5.9",
+        "react-json-editor-ajrm": "2.5.9",
         "react-redux": "5.1.1",
         "react-router-dom": "4.3.1",
         "react-scripts": "^2.1.3",


### PR DESCRIPTION
- Newer version of react-json-editor-ajrm npm package is causing build failure
- Made change to stop upgrading to newer version.